### PR TITLE
Fix \MakeUppercase error in title

### DIFF
--- a/agimus-theme-example.tex
+++ b/agimus-theme-example.tex
@@ -17,7 +17,7 @@
 
 \title{%
     {\small AGIMUS WINTER SCHOOL 2023}\\
-    \MakeUppercase{Course Name}
+    \texorpdfstring{\MakeUppercase{Course Name}}{Course name}
 }
 
 \author{John Author}


### PR DESCRIPTION
The error is:

```
Package beamerthememetropolis Warning: You need to compile with XeLaTeX or LuaL
aTeX to use the Fira fonts on input line 95.

))
(/usr/share/texlive/texmf-dist/tex/latex/beamer/beamerfontthemeprofessionalfont
s.sty))
! Undefined control sequence.
\MakeUppercase ...ppercaseUnsupportedInPdfStrings
```

The issue stems from https://tex.stackexchange.com/a/199385

The reason, if I understand vaguely, is that the title is parsed before the command is properly defined.